### PR TITLE
updating storage alerts with correct operator

### DIFF
--- a/modules/storage-alerts/main.tf
+++ b/modules/storage-alerts/main.tf
@@ -39,7 +39,7 @@ resource "lightstep_metric_condition" "gcp_storage_failed_reqs" {
 
 
     group_by {
-      aggregation_method = "count"
+      aggregation_method = "delta"
       keys               = ["resource_type"]
     }
   }


### PR DESCRIPTION
What are you doing?
switching count -> delta
Why are you doing it?
the API/tf uses delta as the operator vs count (current)